### PR TITLE
Switch to new accountHistory node and re-enable get_history() unit test

### DIFF
--- a/hiveengine/api.py
+++ b/hiveengine/api.py
@@ -2,13 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-import sys
-from datetime import datetime, timedelta, date
-import time
-import json
 import requests
-from timeit import default_timer as timer
-import logging
 from .rpc import RPC
 
 
@@ -27,10 +21,10 @@ class Api(object):
 
     def get_history(self, account, symbol, limit=1000, offset=0):
         """"Get the transaction history for an account and a token"""
-        response = requests.get("https://accounts.hive-engine.com/accountHistory?account=%s&limit=%d&offset=%d&symbol=%s" % (account, limit, offset, symbol))
+        response = requests.get("https://history.hive-engine.com/accountHistory?account=%s&limit=%d&offset=%d&symbol=%s" % (account, limit, offset, symbol))
         cnt2 = 0
         while response.status_code != 200 and cnt2 < 10:
-            response = requests.get("https://accounts.hive-engine.com/accountHistory?account=%s&limit=%d&offset=%d&symbol=%s" % (account, limit, offset, symbol))
+            response = requests.get("https://history.hive-engine.com/accountHistory?account=%s&limit=%d&offset=%d&symbol=%s" % (account, limit, offset, symbol))
             cnt2 += 1
         return response.json()
 
@@ -96,7 +90,7 @@ class Api(object):
         cnt = 0
         result = []
         while last_result is not None and len(last_result) == limit or cnt == 0:
-            cnt += 1            
+            cnt += 1
             last_result = self.find(contract_name, table_name, query, limit=limit, offset=offset)
             if last_result is not None:
                 result += last_result

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from builtins import range
-from builtins import super
 import unittest
 from hiveengine.api import Api
 
@@ -13,22 +11,21 @@ class Testcases(unittest.TestCase):
         api = Api()
         result = api.get_latest_block_info()
         self.assertTrue(len(result) > 0)
-        
+
         result = api.get_block_info(1910)
         self.assertTrue(len(result) > 0)
-        
+
         result = api.get_transaction_info("78aea60cdc4477cdf9437d8224e34c6033499169")
         self.assertTrue(len(result) > 0)
-        
+
         result = api.get_contract("tokens")
         self.assertTrue(len(result) > 0)
-        
+
         result = api.find("tokens", "tokens")
         self.assertTrue(len(result) > 0)
-        
+
         result = api.find_one("tokens", "tokens")
         self.assertTrue(len(result) > 0)
-        
-        # result = api.get_history("holger80", "FOODIE")
-        # self.assertTrue(len(result) > 0)
-     
+
+        result = api.get_history("holger80", "FOODIE")
+        self.assertTrue(len(result) > 0)


### PR DESCRIPTION
Please see message from the Hive-Engine team here: https://discord.com/channels/539442545478991882/539875790536441860/887866751721812018

They are planning to disable `accounts.hive-engine.com` in ~6 days and asking developers to migrate to `history.hive-engine.com/accountHistory`

I made the simple change of URL and re-enabled the corresponding unit test. Also cleaned up some flake8 lint warnings in the files I touched, removing some extra whitespace and unused imports.
